### PR TITLE
Fixed deprecated syntax for apt installation

### DIFF
--- a/tasks/packages-debian.yml
+++ b/tasks/packages-debian.yml
@@ -21,9 +21,8 @@
 
 - name: Install mopidy packages
   apt:
-    name: "{{ item }}"
+    name: "{{ mopidy_packages }}"
     state: present
-  with_items: "{{ mopidy_packages }}"
   notify: restart mopidy
 
 - name: Install gstreamer plugin(s)

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -7,10 +7,9 @@
 - name: Install packages
   apt:
     name: "{{ item }}"
+      - apt-transport-https
+      - autoconf
+      - gcc
+      - python-dev
     state: present
-  with_items:
-    - apt-transport-https
-    - autoconf
-    - gcc
-    - python-dev
   notify: restart mopidy

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -6,7 +6,7 @@
 
 - name: Install packages
   apt:
-    name: "{{ item }}"
+    name:
       - apt-transport-https
       - autoconf
       - gcc


### PR DESCRIPTION
Ansible changed their policy regarding with_items in apt tasks and deprecated that syntax. This PR changes it to the new syntax.